### PR TITLE
MAT-9465: remove incorrectly implemented TranslationResource singleton

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gov.cms.madie</groupId>
 	<artifactId>madie-translator-commons</artifactId>
-	<version>2.1.6-SNAPSHOT</version>
+	<version>2.2.0-SNAPSHOT</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>17</java.version>

--- a/src/main/java/gov/cms/madie/cql_elm_translator/utils/cql/CQLTools.java
+++ b/src/main/java/gov/cms/madie/cql_elm_translator/utils/cql/CQLTools.java
@@ -131,7 +131,7 @@ public class CQLTools {
     this.usingProperties = usingProperties;
 
     TranslationResource translationResource =
-        TranslationResource.getInstance(
+        new TranslationResource(
             usingProperties.getLibraryType().equals("FHIR")
                 || usingProperties
                     .getLibraryType()

--- a/src/main/java/gov/cms/madie/cql_elm_translator/utils/cql/cql_translator/TranslationResource.java
+++ b/src/main/java/gov/cms/madie/cql_elm_translator/utils/cql/cql_translator/TranslationResource.java
@@ -73,8 +73,6 @@ public class TranslationResource {
   private ModelManager modelManager;
   private LibraryManager libraryManager;
 
-  static TranslationResource instance = null;
-
   private String modelType;
   private static final String FHIR = "FHIR";
   private static final String QDM = "QDM";
@@ -83,7 +81,7 @@ public class TranslationResource {
     return libraryManager;
   }
 
-  private TranslationResource(boolean isFhir) {
+  public TranslationResource(boolean isFhir) {
     modelManager = new ModelManager();
     if (isFhir) {
       modelManager.resolveModel(FHIR, "4.0.1");
@@ -99,7 +97,7 @@ public class TranslationResource {
     this.libraryManager = new LibraryManager(modelManager, new CqlCompilerOptions());
   }
 
-  private TranslationResource(ModelManager modelManager, boolean isFhir) {
+  public TranslationResource(ModelManager modelManager, boolean isFhir) {
     this.modelManager = modelManager;
     this.libraryManager = new LibraryManager(modelManager, new CqlCompilerOptions());
     if (isFhir) {
@@ -107,19 +105,6 @@ public class TranslationResource {
     } else {
       modelType = QDM;
     }
-  }
-
-  public static TranslationResource getInstance(boolean isFhir) {
-    instance = new TranslationResource(isFhir);
-    // returns the singleton object
-    return instance;
-  }
-
-  public static TranslationResource getInstance(ModelManager modelManager, boolean isFhir) {
-    if (instance == null) {
-      instance = new TranslationResource(modelManager, isFhir);
-    }
-    return instance;
   }
 
   public CqlTranslator buildTranslator(RequestData requestData) {

--- a/src/main/java/gov/cms/madie/cql_elm_translator/utils/cql/parsing/Cql2ElmListener.java
+++ b/src/main/java/gov/cms/madie/cql_elm_translator/utils/cql/parsing/Cql2ElmListener.java
@@ -704,7 +704,7 @@ public class Cql2ElmListener extends cqlBaseListener {
     ParseTree tree = parser.library();
 
     TranslationResource translationResource =
-        TranslationResource.getInstance(true); // <-- BADDDDD!!!! Defaults to fhir
+        new TranslationResource(true); // <-- BADDDDD!!!! Defaults to fhir
 
     CqlPreprocessorElmCommonVisitor preprocessor =
         new CqlPreprocessorElmCommonVisitor(

--- a/src/test/java/gov/cms/madie/cql_elm_translator/utils/cql/cql_translator/TranslationResourceTest.java
+++ b/src/test/java/gov/cms/madie/cql_elm_translator/utils/cql/cql_translator/TranslationResourceTest.java
@@ -35,7 +35,7 @@ class TranslationResourceTest {
     boolean isFhir = true;
 
     // When
-    TranslationResource resource = TranslationResource.getInstance(mockModelManager, isFhir);
+    TranslationResource resource = new TranslationResource(mockModelManager, isFhir);
 
     // Then
     assertThat(resource, notNullValue());
@@ -51,7 +51,7 @@ class TranslationResourceTest {
     boolean isFhir = false;
 
     // When
-    TranslationResource resource = TranslationResource.getInstance(mockModelManager, isFhir);
+    TranslationResource resource = new TranslationResource(mockModelManager, isFhir);
 
     // Then
     assertThat(resource, notNullValue());


### PR DESCRIPTION
**Breaking change** - remove poorly implemented singleton TranslationResource and update usage as needed

## CQL to ELM Translation Service PR

Jira Ticket: [MAT-9465](https://jira.cms.gov/browse/MAT-9465)
(Optional) Related Tickets:

### Summary
Previously, TranslationResource was implemented looking like a singleton. However, the original instance access method recreated the instance on every call. TranslationResource was never truly a singleton, so the methods and fields that make it appear like a singleton have been removed and usage will need to be updated.

### All Submissions
* [x] This PR has the JIRA linked.
* [ ] Required tests are included.
* [x] No extemporaneous files are included (i.e Complied files or testing results).
* [x] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
