### PR TITLE
MAT-9749: Move creation of the NpmPackageManager out of the fhir translator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gov.cms.madie</groupId>
 	<artifactId>madie-translator-commons</artifactId>
-	<version>3.0.5-SNAPSHOT</version>
+	<version>3.0.6-SNAPSHOT</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>17</java.version>
@@ -70,13 +70,18 @@
 			<artifactId>jul-to-slf4j</artifactId>
 			<version>${slf4j.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.fhir</groupId>
+			<artifactId>ucum</artifactId>
+			<version>${org.fhir.ucum.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.cqframework</groupId>
 			<artifactId>cql</artifactId>
 			<version>${cqframework.version}</version>
 		</dependency>
-
-
 		<dependency>
 			<groupId>org.cqframework</groupId>
 			<artifactId>cql-to-elm</artifactId>
@@ -87,12 +92,6 @@
             <artifactId>cql-to-elm-jvm</artifactId>
             <version>${cqframework.version}</version>
         </dependency>
-
-		<dependency>
-			<groupId>org.fhir</groupId>
-			<artifactId>ucum</artifactId>
-			<version>${org.fhir.ucum.version}</version>
-		</dependency>
 		<dependency>
 			<groupId>org.cqframework</groupId>
 			<artifactId>elm</artifactId>
@@ -103,6 +102,37 @@
             <artifactId>elm-fhir</artifactId>
             <version>${cqframework.version}</version>
         </dependency>
+		<dependency>
+			<groupId>org.cqframework</groupId>
+			<artifactId>cqf-fhir-npm</artifactId>
+			<version>${cqframework.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.cqframework</groupId>
+			<artifactId>quick</artifactId>
+			<version>${cqframework.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.cqframework</groupId>
+			<artifactId>qdm</artifactId>
+			<version>${cqframework.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.cqframework</groupId>
+			<artifactId>cql-formatter</artifactId>
+			<version>${cqframework.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib</artifactId>
+			<version>${kotlin.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+			<version>${kotlin.version}</version>
+		</dependency>
 
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
@@ -115,7 +145,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-converter</artifactId>
@@ -123,44 +152,17 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.cqframework</groupId>
-			<artifactId>quick</artifactId>
-			<version>${cqframework.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.cqframework</groupId>
-			<artifactId>qdm</artifactId>
-			<version>${cqframework.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.cqframework</groupId>
-			<artifactId>cql-formatter</artifactId>
-			<version>${cqframework.version}</version>
-		</dependency>
-
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-reflect</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-
-		<dependency>
 			<groupId>gov.cms.madie</groupId>
 			<artifactId>madie-rest-commons</artifactId>
 			<version>${madie.rest.commons.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>javax.ws.rs</groupId>
 			<artifactId>javax.ws.rs-api</artifactId>
 			<version>2.1.1</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
@@ -262,6 +264,20 @@
 			<groupId>com.jayway.jsonpath</groupId>
 			<artifactId>json-path</artifactId>
 			<version>${com.jayway.jsonpath.version}</version>
+		</dependency>
+		<!-- Ensuring alignment of transitive dependencies needed to parse IG npm packages
+		 with hl7.fhir.utilities.npm classes -->
+		<!-- Force commons-io >= 2.18.0 to fix IllegalAccessError caused by commons-compress 1.28.0
+     calling AbstractStreamBuilder.getInputStream() which was narrowed to protected in 2.17.0 -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+			<version>1.28.0</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.21.0</version>
 		</dependency>
 	</dependencies>
 	<!--    Required to fetch artifacts from repositories other than maven central -->

--- a/src/main/java/gov/cms/madie/cql_elm_translator/utils/ImplementationGuideLoader.java
+++ b/src/main/java/gov/cms/madie/cql_elm_translator/utils/ImplementationGuideLoader.java
@@ -2,12 +2,16 @@ package gov.cms.madie.cql_elm_translator.utils;
 
 import ca.uhn.fhir.context.FhirContext;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.cqframework.fhir.npm.NpmPackageManager;
 import org.hl7.fhir.convertors.advisors.impl.BaseAdvisor_40_50;
 import org.hl7.fhir.convertors.conv40_50.VersionConvertor_40_50;
 import org.hl7.fhir.r5.model.ImplementationGuide;
 import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +44,18 @@ public class ImplementationGuideLoader {
     return igs;
   }
 
-  protected static ImplementationGuide parseFromInputStream(InputStream inputStream) {
+  public static NpmPackageManager buildPackageManager(
+      String fhirCachePath, ImplementationGuide implementationGuide) throws IOException {
+    FilesystemPackageCacheManager.Builder fspcmBuilder =
+        new FilesystemPackageCacheManager.Builder();
+    if (StringUtils.isNotBlank(fhirCachePath)) {
+      fspcmBuilder = fspcmBuilder.withCacheFolder(fhirCachePath);
+    }
+    FilesystemPackageCacheManager fspcm = fspcmBuilder.build();
+    return new NpmPackageManager(implementationGuide, fspcm);
+  }
+
+  public static ImplementationGuide parseFromInputStream(InputStream inputStream) {
     Resource igResource =
         (Resource) FhirContext.forR4Cached().newJsonParser().parseResource(inputStream);
 


### PR DESCRIPTION
## CQL to ELM Translation Service PR

Jira Ticket: [MAT-9749](https://jira.cms.gov/browse/MAT-9749)
(Optional) Related Tickets:

### Summary

Moving the initilzation of the `NpmPackageManager` from translator to commons to make it available to the terminology-service for IG npm package parsing.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
