### PR TITLE
MAT-9834: Catch Cache.ValueRetrievalException in getLibraryCql and re…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gov.cms.madie</groupId>
 	<artifactId>madie-translator-commons</artifactId>
-	<version>3.1.1</version>
+	<version>3.1.2</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>17</java.version>

--- a/src/main/java/gov/cms/madie/cql_elm_translator/service/CqlLibraryService.java
+++ b/src/main/java/gov/cms/madie/cql_elm_translator/service/CqlLibraryService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.cqframework.cql.cql2elm.CqlIncludeException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -46,9 +47,13 @@ public class CqlLibraryService {
 
   public String getLibraryCql(String name, String version, String accessToken) {
     if (cacheManager != null) {
-      return cacheManager
-          .getCache("cqlLibraries")
-          .get(name + "_" + version, () -> fetchLibraryCql(name, version, accessToken));
+      try {
+        return cacheManager
+            .getCache("cqlLibraries")
+            .get(name + "_" + version, () -> fetchLibraryCql(name, version, accessToken));
+      } catch (Cache.ValueRetrievalException e) {
+        throw (RuntimeException) e.getCause();
+      }
     }
     return fetchLibraryCql(name, version, accessToken);
   }

--- a/src/test/java/gov/cms/madie/cql_elm_translator/services/CqlLibraryServiceTest.java
+++ b/src/test/java/gov/cms/madie/cql_elm_translator/services/CqlLibraryServiceTest.java
@@ -12,7 +12,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import org.springframework.cache.Cache;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -234,17 +233,13 @@ class CqlLibraryServiceTest {
         .when(restTemplate)
         .exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class));
 
-    Cache.ValueRetrievalException ex1 =
-        assertThrows(
-            Cache.ValueRetrievalException.class,
-            () -> cqlLibraryService.getLibraryCql(cqlLibraryName, cqlLibraryVersion, accessToken));
-    assertInstanceOf(LibraryResourceLoaderException.class, ex1.getCause());
+    assertThrows(
+        LibraryResourceLoaderException.class,
+        () -> cqlLibraryService.getLibraryCql(cqlLibraryName, cqlLibraryVersion, accessToken));
 
-    Cache.ValueRetrievalException ex2 =
-        assertThrows(
-            Cache.ValueRetrievalException.class,
-            () -> cqlLibraryService.getLibraryCql(cqlLibraryName, cqlLibraryVersion, accessToken));
-    assertInstanceOf(LibraryResourceLoaderException.class, ex2.getCause());
+    assertThrows(
+        LibraryResourceLoaderException.class,
+        () -> cqlLibraryService.getLibraryCql(cqlLibraryName, cqlLibraryVersion, accessToken));
 
     verify(restTemplate, times(2)).exchange(any(URI.class), any(), any(), eq(String.class));
   }


### PR DESCRIPTION
…throw the cause directly, restoring pre-caching exception behavior for all error cases

## CQL to ELM Translation Service PR

Jira Ticket: [MAT-9834](https://jira.cms.gov/browse/MAT-9834)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
