### PR TITLE
MAT-10058: update spring boot (from 3.5.14 to 4.0.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,3 @@
 |--------------------|-------------------------|
 | 1.x.y              | \>= 3.3.2 and <= 3.14.0 |
 | 2.x.y              | \>= 3.15.0              |
-
-
-## Publishing SNAPSHOT for madie-fhir-elm-translator
-- Create a PR with necessary changes against develop branch
-- Make sure you update the package version example: <version>2.0.5-SNAPSHOT</version>
-- On Merge to Develop a SNAPSHOT version will be published.
-
-## Publishing a Release for madie-fhir-elm-translator
-- Create a PR with necessary changes against main branch
-- Make sure you update the package version example: <version>2.0.5</version>
-- On Merge to main a release version will be published.
-
-## Publishing a Release for madie-qdm-elm-translator
-- Using the latest tag v1.x.y create a new branch with name as of the next release ex: if the Latest tag is 1.0.4 then based on that tag create a new branch "1.0.5"
-- Using the latest tag create another feature branch ex:feature/MAT-1234 and push your changes.
-- Make sure you update the package version (pom.xml) to: <version>1.0.5</version>
-- Also update the release.yml file with the new version number, as per our example it is 1.0.5
-- Create a PR for feature/MAT-1234 against the new branch 1.0.5
-- On Merge to branch 1.0.5 a release version will be published and a new tag will be automatically generated.

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<checkstyle.file>madie-checkstyle.xml</checkstyle.file>
 		<gov.cms.madie.models.version>0.10.0-SNAPSHOT</gov.cms.madie.models.version>
 		<com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
-		<org.springframework.boot.version>4.0.6</org.springframework.boot.version>
+		<org.springframework.boot.version>4.0.7</org.springframework.boot.version>
 		<org.fhir.ucum.version>1.0.9</org.fhir.ucum.version>
         <kotlin.version>2.2.10</kotlin.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>gov.cms.madie</groupId>
 	<artifactId>madie-translator-commons</artifactId>
-	<version>3.4.0</version>
+	<version>3.5.0</version>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>17</java.version>
@@ -17,15 +17,15 @@
 		<hapi.fhir.version>8.10.0</hapi.fhir.version>
 		<spotify.fmt.version>2.21.1</spotify.fmt.version>
 		<lombok.version>1.18.30</lombok.version>
-		<madie.rest.commons.version>1.0.6-SNAPSHOT</madie.rest.commons.version>
+		<madie.rest.commons.version>1.1.0-SNAPSHOT</madie.rest.commons.version>
 		<hamcrest.version>3.0-rc1</hamcrest.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
-		<spring.test.version>6.1.14</spring.test.version>
+		<spring.test.version>7.0.7</spring.test.version>
 		<checkstyle.version>3.4.0</checkstyle.version>
 		<checkstyle.file>madie-checkstyle.xml</checkstyle.file>
-		<gov.cms.madie.models.version>0.6.56-SNAPSHOT</gov.cms.madie.models.version>
+		<gov.cms.madie.models.version>0.10.0-SNAPSHOT</gov.cms.madie.models.version>
 		<com.jayway.jsonpath.version>2.9.0</com.jayway.jsonpath.version>
-		<org.springframework.boot.version>3.5.14</org.springframework.boot.version>
+		<org.springframework.boot.version>4.0.6</org.springframework.boot.version>
 		<org.fhir.ucum.version>1.0.9</org.fhir.ucum.version>
         <kotlin.version>2.2.10</kotlin.version>
 	</properties>
@@ -39,6 +39,13 @@
 	</distributionManagement>
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-dependencies</artifactId>
+				<version>${org.springframework.boot.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 			<dependency>
 				<groupId>net.minidev</groupId>
 				<artifactId>json-smart</artifactId>
@@ -179,6 +186,11 @@
 			</exclusions>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-restclient</artifactId>
+			<version>${org.springframework.boot.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.persistence</groupId>
 			<artifactId>org.eclipse.persistence.moxy</artifactId>
 			<version>4.0.2</version>
@@ -190,12 +202,9 @@
 			<version>${org.springframework.boot.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<!--
-		https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.11.0-M2</version>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest -->

--- a/src/main/java/gov/cms/madie/cql_elm_translator/config/RestTemplateConfig.java
+++ b/src/main/java/gov/cms/madie/cql_elm_translator/config/RestTemplateConfig.java
@@ -1,7 +1,7 @@
 package gov.cms.madie.cql_elm_translator.config;
 
 import gov.cms.madie.cql_elm_translator.config.logging.RequestResponseLoggingMdcInternalInterceptor;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;

--- a/src/main/java/gov/cms/madie/cql_elm_translator/dto/SourceDataCriteria.java
+++ b/src/main/java/gov/cms/madie/cql_elm_translator/dto/SourceDataCriteria.java
@@ -1,12 +1,16 @@
 package gov.cms.madie.cql_elm_translator.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Comparator;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SourceDataCriteria implements Comparable<SourceDataCriteria> {
   private String oid;
   private String title;

--- a/src/main/java/gov/cms/madie/cql_elm_translator/service/CqlLibraryService.java
+++ b/src/main/java/gov/cms/madie/cql_elm_translator/service/CqlLibraryService.java
@@ -157,7 +157,7 @@ public class CqlLibraryService {
   }
 
   private URI buildMadieLibraryServiceUri(String name, String version) {
-    return UriComponentsBuilder.fromHttpUrl(madieLibraryService + librariesCqlUri)
+    return UriComponentsBuilder.fromUriString(madieLibraryService + librariesCqlUri)
         .queryParam("name", name)
         .queryParam("version", version)
         .build()

--- a/src/main/java/gov/cms/madie/cql_elm_translator/utils/cql/parsing/model/CQLCode.java
+++ b/src/main/java/gov/cms/madie/cql_elm_translator/utils/cql/parsing/model/CQLCode.java
@@ -1,5 +1,6 @@
 package gov.cms.madie.cql_elm_translator.utils.cql.parsing.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -39,12 +40,14 @@ public class CQLCode implements CQLExpression {
 
   private String codeIdentifier;
 
+  @JsonProperty("used")
   private boolean isUsed;
 
   private boolean readOnly;
 
   private String suffix;
 
+  @JsonProperty("codeSystemVersionIncluded")
   private boolean isCodeSystemVersionIncluded;
 
   private String isValidatedWithVsac = "VALID";

--- a/src/main/java/gov/cms/madie/cql_elm_translator/utils/cql/parsing/model/CQLDefinition.java
+++ b/src/main/java/gov/cms/madie/cql_elm_translator/utils/cql/parsing/model/CQLDefinition.java
@@ -1,5 +1,7 @@
 package gov.cms.madie.cql_elm_translator.utils.cql.parsing.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -27,7 +29,10 @@ public class CQLDefinition implements CQLExpression {
   private String parentLibrary;
   private String libraryDisplayName;
   private String libraryVersion;
+
+  @JsonProperty("function")
   private boolean isFunction;
+
   private int startLine;
   private List<CQLFunctionArgument> functionArguments;
 

--- a/src/test/java/gov/cms/madie/cql_elm_translator/services/CqlLibraryServiceTest.java
+++ b/src/test/java/gov/cms/madie/cql_elm_translator/services/CqlLibraryServiceTest.java
@@ -272,7 +272,7 @@ class CqlLibraryServiceTest {
   void getLibraryCqlReturnsNull() {
     when(restTemplate.exchange(
             libraryUri, HttpMethod.GET, new HttpEntity<>(httpHeaders), String.class))
-        .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
+        .thenReturn(new ResponseEntity<String>(HttpStatus.OK));
     String responseBody =
         cqlLibraryService.getLibraryCql(cqlLibraryName, cqlLibraryVersion, accessToken);
     assertNull(responseBody);


### PR DESCRIPTION
## CQL to ELM Translation Service PR

Jira Ticket: [MAT-10058](https://jira.cms.gov/browse/MAT-10058)
(Optional) Related Tickets:

### Summary

# Spring Boot 4 + Jackson 3 Upgrade Notes — madie-translator-commons

Part of the fleet-wide SB 3.5.14 → 4.0.6 + Jackson 2 → 3 migration. Common patterns live in
`madie-fhir-service/SPRING_BOOT_4_UPGRADE.md`; this file records only what was specific to this repo.

This library was already on Spring Boot 4.0.6 from MAT-10056. The Jackson 3 step here was essentially just
a rebuild against the now-Jackson-3 foundation libraries, because translator-commons is **Jackson-neutral**:
it excludes Jackson from its `madie-java-models` dependency and its only `RestTemplate` does `String`-only
exchanges, so it carries no Jackson (de)serialization of its own.

## Version
`3.4.0` → **`3.5.0`**

## pom.xml
- `gov.cms.madie.models.version` (java-models pin) `0.6.56-SNAPSHOT` → `0.10.0-SNAPSHOT`.
- `madie.rest.commons.version` `1.0.6-SNAPSHOT` → `1.1.0-SNAPSHOT`.
- No Jackson coordinate changes needed (Jackson-neutral). No source changes.
- Still carries the defensive `spring-boot-dependencies` BOM import added during MAT-10056. Now that
  `madie-rest-commons` is on SB4 the SF6 leak is gone, so this import is no longer strictly required —
  left in place (harmless) and can be removed in a later cleanup.

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included.
* [ ] No extemporaneous files are included (i.e Complied files or testing results).
* [ ] This PR is merging into the **correct branch**.
* [ ] All Documentation needed for this PR is Complete (or noted in a TODO or other Ticket).
* [ ] Any breaking changes or failing automations are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package).

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose.
*  The tests appropriately test the new code, including edge cases.
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads.
